### PR TITLE
Update howToSetupStormOnCentos.txt

### DIFF
--- a/learnStorm/howToSetupStormOnCentos.txt
+++ b/learnStorm/howToSetupStormOnCentos.txt
@@ -170,7 +170,7 @@ Procedure
 
        	
 10. Launch daemons under supervision using "storm" script and a supervisor of your choice
-    unix> export PATH=PATH:/opt/apache-storm-1.0.1/bin
+    unix> export PATH=$PATH:/opt/apache-storm-1.0.1/bin
     unix> storm nimbus &
     unix> tail -f /opt/apache-storm-1.0.1/logs/nimbus.log
     


### PR DESCRIPTION
"export PATH=PATH:/opt/apache-storm-1.0.1/bin" overwrites PATH, while "export PATH=$PATH:/opt/apache-storm-1.0.1/bin" appends to PATH which is the behaviour I think is necessary here.